### PR TITLE
Remove `set_disable_data_sync`

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,6 @@ fn badly_tuned_for_somebody_elses_disk() -> DB {
     opts.set_max_open_files(10000);
     opts.set_use_fsync(false);
     opts.set_bytes_per_sync(8388608);
-    opts.set_disable_data_sync(false);
     opts.set_block_cache_size_mb(1024);
     opts.set_table_cache_num_shard_bits(6);
     opts.set_max_write_buffer_number(32);

--- a/rocksdb-sys/src/ffi.rs
+++ b/rocksdb-sys/src/ffi.rs
@@ -151,8 +151,6 @@ extern "C" {
                                               files: c_int);
     pub fn rocksdb_options_set_use_fsync(options: DBOptions, v: c_int);
     pub fn rocksdb_options_set_bytes_per_sync(options: DBOptions, bytes: u64);
-    pub fn rocksdb_options_set_disable_data_sync(options: DBOptions,
-                                                 v: c_int);
     pub fn rocksdb_options_optimize_for_point_lookup(options: DBOptions,
                                                      block_cache_size_mb: u64);
     pub fn rocksdb_options_set_table_cache_numshardbits(options: DBOptions,

--- a/src/main.rs
+++ b/src/main.rs
@@ -154,7 +154,6 @@ mod tests {
         opts.set_max_open_files(10000);
         opts.set_use_fsync(false);
         opts.set_bytes_per_sync(8388608);
-        opts.set_disable_data_sync(false);
         opts.set_block_cache_size_mb(1024);
         opts.set_table_cache_num_shard_bits(6);
         opts.set_max_write_buffer_number(32);

--- a/src/rocksdb_options.rs
+++ b/src/rocksdb_options.rs
@@ -251,19 +251,6 @@ impl Options {
         }
     }
 
-    pub fn set_disable_data_sync(&mut self, disable: bool) {
-        unsafe {
-            match disable {
-                true =>
-                    rocksdb_ffi::rocksdb_options_set_disable_data_sync(
-                        self.inner, 1),
-                false =>
-                    rocksdb_ffi::rocksdb_options_set_disable_data_sync(
-                        self.inner, 0),
-            }
-        }
-    }
-
     pub fn set_table_cache_num_shard_bits(&mut self, nbits: c_int) {
         unsafe {
             rocksdb_ffi::rocksdb_options_set_table_cache_numshardbits(self.inner,


### PR DESCRIPTION
This setting has been removed on RocksDB and having the reference in the ffi causes loading the shared library to break on Windows (https://gitlab.parity.io/parity/parity/-/jobs/74728).

Based on https://github.com/spacejam/rust-rocksdb/pull/139.