### PR TITLE
Rename crate to parity-rocksdb

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,10 @@
 *.swo
 *.swp
-target
-Cargo.lock
 *.orig
 *.bk
 _rust_rocksdb*
 *rlib
 tags
 .idea
+**/Cargo.lock
+**/target/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,16 +1,16 @@
 [package]
 
-name = "rocksdb"
+name = "parity-rocksdb"
 description = "A Rust wrapper for Facebook's RocksDB embeddable database."
-version = "0.4.5"
-authors = ["Tyler Neely <t@jujit.su>", "David Greenberg <dsg123456789@gmail.com>"]
+version = "0.5.0"
+authors = ["Parity Technologies <admin@parity.io>"]
 license = "Apache-2.0"
 keywords = ["database", "embedded", "LSM-tree", "persistence"]
 homepage = "https://github.com/paritytech/rust-rocksdb"
 exclude = [
+  ".appveyor.yml",
   ".gitignore",
   ".travis.yml",
-  "deploy.sh",
   "test/**/*",
 ]
 
@@ -25,5 +25,5 @@ path = "test/test.rs"
 
 [dependencies]
 libc = "0.2"
-rocksdb-sys = { path = "rocksdb-sys", version = "0.3.0" }
+parity-rocksdb-sys = { path = "rocksdb-sys", version = "0.5.0" }
 local-encoding = "0.2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "parity-rocksdb"
 description = "A Rust wrapper for Facebook's RocksDB embeddable database."
-version = "0.5.0"
+version = "0.5.0-beta.0"
 authors = ["Tyler Neely <t@jujit.su>", "David Greenberg <dsg123456789@gmail.com>", "Parity Technologies <admin@parity.io>"]
 license = "Apache-2.0"
 keywords = ["database", "embedded", "LSM-tree", "persistence"]
@@ -24,5 +24,5 @@ path = "test/test.rs"
 
 [dependencies]
 libc = "0.2"
-parity-rocksdb-sys = { path = "rocksdb-sys", version = "0.5.0" }
+parity-rocksdb-sys = { path = "rocksdb-sys", version = "0.5.0-beta" }
 local-encoding = "0.2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "parity-rocksdb"
 description = "A Rust wrapper for Facebook's RocksDB embeddable database."
-version = "0.5.0-beta.0"
+version = "0.5.0"
 authors = ["Tyler Neely <t@jujit.su>", "David Greenberg <dsg123456789@gmail.com>", "Parity Technologies <admin@parity.io>"]
 license = "Apache-2.0"
 keywords = ["database", "embedded", "LSM-tree", "persistence"]
@@ -24,5 +24,5 @@ path = "test/test.rs"
 
 [dependencies]
 libc = "0.2"
-parity-rocksdb-sys = { path = "rocksdb-sys", version = "0.5.0-beta" }
+parity-rocksdb-sys = { path = "rocksdb-sys", version = "0.5" }
 local-encoding = "0.2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,8 @@
 [package]
-
 name = "parity-rocksdb"
 description = "A Rust wrapper for Facebook's RocksDB embeddable database."
 version = "0.5.0"
-authors = ["Parity Technologies <admin@parity.io>"]
+authors = ["Tyler Neely <t@jujit.su>", "David Greenberg <dsg123456789@gmail.com>", "Parity Technologies <admin@parity.io>"]
 license = "Apache-2.0"
 keywords = ["database", "embedded", "LSM-tree", "persistence"]
 homepage = "https://github.com/paritytech/rust-rocksdb"

--- a/rocksdb-sys/.gitignore
+++ b/rocksdb-sys/.gitignore
@@ -1,2 +1,0 @@
-target
-Cargo.lock

--- a/rocksdb-sys/Cargo.toml
+++ b/rocksdb-sys/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "parity-rocksdb-sys"
 version = "0.5.0"
-authors = ["Parity Technologies <admin@parity.io>"]
+authors = ["Tyler Neely <t@jujit.su>", "David Greenberg <dsg123456789@gmail.com>", "Parity Technologies <admin@parity.io>"]
 license = "MIT/Apache-2.0/BSD"
 description = "Native bindings to librocksdb"
 readme = "README.md"

--- a/rocksdb-sys/Cargo.toml
+++ b/rocksdb-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parity-rocksdb-sys"
-version = "0.5.0-beta.0"
+version = "0.5.0"
 authors = ["Tyler Neely <t@jujit.su>", "David Greenberg <dsg123456789@gmail.com>", "Parity Technologies <admin@parity.io>"]
 license = "MIT/Apache-2.0/BSD-3-Clause"
 description = "Native bindings to librocksdb"
@@ -17,7 +17,7 @@ default = []
 [dependencies]
 libc = "0.2"
 local-encoding = "0.2.0"
-parity-snappy-sys = "0.1.0-beta"
+parity-snappy-sys = "0.1"
 
 [build-dependencies]
 cmake = "0.1"

--- a/rocksdb-sys/Cargo.toml
+++ b/rocksdb-sys/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "parity-rocksdb-sys"
-version = "0.5.0"
+version = "0.5.0-beta.0"
 authors = ["Tyler Neely <t@jujit.su>", "David Greenberg <dsg123456789@gmail.com>", "Parity Technologies <admin@parity.io>"]
-license = "MIT/Apache-2.0/BSD"
+license = "MIT/Apache-2.0/BSD-3-Clause"
 description = "Native bindings to librocksdb"
 readme = "README.md"
 repository = "https://github.com/paritytech/rust-rocksdb.git"
@@ -17,7 +17,7 @@ default = []
 [dependencies]
 libc = "0.2"
 local-encoding = "0.2.0"
-snappy-sys = { git = "https://github.com/paritytech/rust-snappy" }
+parity-snappy-sys = "0.1.0-beta"
 
 [build-dependencies]
 cmake = "0.1"

--- a/rocksdb-sys/Cargo.toml
+++ b/rocksdb-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parity-rocksdb-sys"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["Tyler Neely <t@jujit.su>", "David Greenberg <dsg123456789@gmail.com>", "Parity Technologies <admin@parity.io>"]
 license = "MIT/Apache-2.0/BSD-3-Clause"
 description = "Native bindings to librocksdb"

--- a/rocksdb-sys/Cargo.toml
+++ b/rocksdb-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parity-rocksdb-sys"
-version = "0.5.1"
+version = "0.5.2"
 authors = ["Tyler Neely <t@jujit.su>", "David Greenberg <dsg123456789@gmail.com>", "Parity Technologies <admin@parity.io>"]
 license = "MIT/Apache-2.0/BSD-3-Clause"
 description = "Native bindings to librocksdb"

--- a/rocksdb-sys/Cargo.toml
+++ b/rocksdb-sys/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
-name = "rocksdb-sys"
-version = "0.3.0"
-authors = ["Arkadiy Paronyan arkadiy@ethcore.io>"]
+name = "parity-rocksdb-sys"
+version = "0.5.0"
+authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT/Apache-2.0/BSD"
 description = "Native bindings to librocksdb"
 readme = "README.md"

--- a/rocksdb-sys/build.rs
+++ b/rocksdb-sys/build.rs
@@ -13,6 +13,15 @@ fn main() {
 
     let snappy = env::var_os("DEP_SNAPPY_INCLUDE").expect("DEP_SNAPPY_INCLUDE is set in snappy.");
 
+    // NOTE: the cfg! macro doesn't work when cross-compiling, it would return values for the host
+    let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
+    let target_android = target_os.contains("android");
+
+    if target_android {
+        // when cross-compiling CMAKE_SYSTEM_NAME is set to the host OS
+        cfg.define("CMAKE_SYSTEM_NAME", "Android");
+    }
+
     if cfg!(target_env = "msvc") {
         cfg.env("SNAPPY_INCLUDE", snappy);
 
@@ -28,7 +37,6 @@ fn main() {
             .define("SNAPPY_LIBRARIES", "/dev/null");
     }
 
-    // NOTE: the cfg! macro doesn't work when cross-compiling, it would return values for the host
     let target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap_or_default();
     if target_arch == "arm" || target_arch == "aarch64" {
         cfg.define("PORTABLE", "ON");
@@ -53,7 +61,7 @@ fn main() {
     // https://github.com/alexcrichton/cc-rs/blob/ca70fd32c10f8cea805700e944f3a8d1f97d96d4/src/lib.rs#L891
     if cfg!(any(target_os = "macos", target_os = "freebsd", target_os = "openbsd")) {
         println!("cargo:rustc-link-lib=c++");
-	} else if cfg!(not(any(target_env = "msvc", target_os = "android"))) {
+	} else if cfg!(not(target_env = "msvc")) && !target_android {
         println!("cargo:rustc-link-lib=stdc++");
     }
 }

--- a/rocksdb-sys/build.rs
+++ b/rocksdb-sys/build.rs
@@ -14,7 +14,7 @@ fn main() {
     let snappy = env::var_os("DEP_SNAPPY_INCLUDE").expect("DEP_SNAPPY_INCLUDE is set in snappy.");
 
     // NOTE: the cfg! macro doesn't work when cross-compiling, it would return values for the host
-    let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
+    let target_os = env::var("CARGO_CFG_TARGET_OS").expect("CARGO_CFG_TARGET_OS is set by cargo.");
     let target_android = target_os.contains("android");
 
     if target_android {
@@ -28,7 +28,9 @@ fn main() {
         println!("cargo:rustc-link-lib=dylib={}", "rpcrt4");
         println!("cargo:rustc-link-lib=dylib={}", "shlwapi");
 
-        let features = env::var("CARGO_CFG_TARGET_FEATURE").unwrap_or_default();
+        let features = env::var("CARGO_CFG_TARGET_FEATURE")
+            .expect("CARGO_CFG_TARGET_FEATURE is set by cargo.");
+
         if features.contains("crt-static") {
             cfg.define("WITH_MD_LIBRARY", "OFF");
         }
@@ -37,7 +39,9 @@ fn main() {
             .define("SNAPPY_LIBRARIES", "/dev/null");
     }
 
-    let target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap_or_default();
+    let target_arch = env::var("CARGO_CFG_TARGET_ARCH")
+        .expect("CARGO_CFG_TARGET_ARCH is set by cargo.");
+
     if target_arch == "arm" || target_arch == "aarch64" {
         cfg.define("PORTABLE", "ON");
     }

--- a/rocksdb-sys/build.rs
+++ b/rocksdb-sys/build.rs
@@ -16,14 +16,14 @@ fn main() {
 
     // NOTE: the cfg! macro doesn't work when cross-compiling, it would return values for the host
     let target_os = env::var("CARGO_CFG_TARGET_OS").expect("CARGO_CFG_TARGET_OS is set by cargo.");
-    let target_android = target_os.contains("android");
+	let target_env = env::var("CARGO_CFG_TARGET_ENV").expect("CARGO_CFG_TARGET_ENV is set by cargo.");
 
-    if target_android {
+    if target_os.contains("android") {
         // when cross-compiling CMAKE_SYSTEM_NAME is set to the host OS
         cfg.define("CMAKE_SYSTEM_NAME", "Android");
     }
 
-    if cfg!(target_env = "msvc") {
+    if target_env.contains("msvc") {
         cfg.env("SNAPPY_INCLUDE", snappy);
 
         println!("cargo:rustc-link-lib=dylib={}", "rpcrt4");
@@ -51,7 +51,7 @@ fn main() {
 
     let mut build = out.join("build");
 
-    if cfg!(target_os = "windows") {
+    if target_os.contains("windows") {
         let profile = match &*env::var("PROFILE").unwrap_or("debug".to_owned()) {
             "bench" | "release" => "Release",
             _ => "Debug",
@@ -64,9 +64,9 @@ fn main() {
     println!("cargo:rustc-link-lib=static=snappy");
 
     // https://github.com/alexcrichton/cc-rs/blob/ca70fd32c10f8cea805700e944f3a8d1f97d96d4/src/lib.rs#L891
-    if cfg!(any(target_os = "macos", target_os = "freebsd", target_os = "openbsd")) {
-        println!("cargo:rustc-link-lib=c++");
-	} else if cfg!(not(target_env = "msvc")) && !target_android {
-        println!("cargo:rustc-link-lib=stdc++");
-    }
+	if target_os.contains("macos") || target_os.contains("freebsd") || target_os.contains("openbsd") {
+		println!("cargo:rustc-link-lib=c++");
+	} else if !target_env.contains("msvc") && !target_os.contains("android") {
+		println!("cargo:rustc-link-lib=stdc++");
+	}
 }

--- a/rocksdb-sys/build.rs
+++ b/rocksdb-sys/build.rs
@@ -16,7 +16,7 @@ fn main() {
 
     // NOTE: the cfg! macro doesn't work when cross-compiling, it would return values for the host
     let target_os = env::var("CARGO_CFG_TARGET_OS").expect("CARGO_CFG_TARGET_OS is set by cargo.");
-	let target_env = env::var("CARGO_CFG_TARGET_ENV").expect("CARGO_CFG_TARGET_ENV is set by cargo.");
+    let target_env = env::var("CARGO_CFG_TARGET_ENV").expect("CARGO_CFG_TARGET_ENV is set by cargo.");
 
     if target_os.contains("android") {
         // when cross-compiling CMAKE_SYSTEM_NAME is set to the host OS
@@ -64,9 +64,9 @@ fn main() {
     println!("cargo:rustc-link-lib=static=snappy");
 
     // https://github.com/alexcrichton/cc-rs/blob/ca70fd32c10f8cea805700e944f3a8d1f97d96d4/src/lib.rs#L891
-	if target_os.contains("macos") || target_os.contains("freebsd") || target_os.contains("openbsd") {
-		println!("cargo:rustc-link-lib=c++");
-	} else if !target_env.contains("msvc") && !target_os.contains("android") {
-		println!("cargo:rustc-link-lib=stdc++");
-	}
+    if target_os.contains("macos") || target_os.contains("freebsd") || target_os.contains("openbsd") {
+        println!("cargo:rustc-link-lib=c++");
+    } else if !target_env.contains("msvc") && !target_os.contains("android") {
+        println!("cargo:rustc-link-lib=stdc++");
+    }
 }

--- a/rocksdb-sys/build.rs
+++ b/rocksdb-sys/build.rs
@@ -9,6 +9,7 @@ fn main() {
     cfg.define("CMAKE_VERBOSE_MAKEFILE", "ON")
         .register_dep("SNAPPY")
         .define("WITH_SNAPPY", "ON")
+        .define("FAIL_ON_WARNINGS", "OFF")
         .build_target("rocksdb");
 
     let snappy = env::var_os("DEP_SNAPPY_INCLUDE").expect("DEP_SNAPPY_INCLUDE is set in snappy.");

--- a/rocksdb-sys/rocksdb/CMakeLists.txt
+++ b/rocksdb-sys/rocksdb/CMakeLists.txt
@@ -210,7 +210,7 @@ else()
 endif()
 
 include(CheckCXXSourceCompiles)
-if(NOT MSVC)
+if(NOT MSVC AND NOT PORTABLE)
   set(CMAKE_REQUIRED_FLAGS "-msse4.2 -mpclmul")
 endif()
 

--- a/rocksdb-sys/rocksdb/CMakeLists.txt
+++ b/rocksdb-sys/rocksdb/CMakeLists.txt
@@ -213,7 +213,9 @@ include(CheckCXXSourceCompiles)
 if(NOT MSVC)
   set(CMAKE_REQUIRED_FLAGS "-msse4.2 -mpclmul")
 endif()
-CHECK_CXX_SOURCE_COMPILES("
+
+if(NOT PORTABLE)
+  CHECK_CXX_SOURCE_COMPILES("
 #include <cstdint>
 #include <nmmintrin.h>
 #include <wmmintrin.h>
@@ -225,15 +227,15 @@ int main() {
   auto d = _mm_cvtsi128_si64(c);
 }
 " HAVE_SSE42)
-unset(CMAKE_REQUIRED_FLAGS)
-if(HAVE_SSE42)
-  add_definitions(-DHAVE_SSE42)
-  add_definitions(-DHAVE_PCLMUL)
-elseif(FORCE_SSE42)
-  message(FATAL_ERROR "FORCE_SSE42=ON but unable to compile with SSE4.2 enabled")
-endif()
+  unset(CMAKE_REQUIRED_FLAGS)
+  if(HAVE_SSE42)
+    add_definitions(-DHAVE_SSE42)
+    add_definitions(-DHAVE_PCLMUL)
+  elseif(FORCE_SSE42)
+    message(FATAL_ERROR "FORCE_SSE42=ON but unable to compile with SSE4.2 enabled")
+  endif()
 
-CHECK_CXX_SOURCE_COMPILES("
+  CHECK_CXX_SOURCE_COMPILES("
 #if defined(_MSC_VER) && !defined(__thread)
 #define __thread __declspec(thread)
 #endif
@@ -241,8 +243,9 @@ int main() {
   static __thread int tls;
 }
 " HAVE_THREAD_LOCAL)
-if(HAVE_THREAD_LOCAL)
-  add_definitions(-DROCKSDB_SUPPORT_THREAD_LOCAL)
+  if(HAVE_THREAD_LOCAL)
+    add_definitions(-DROCKSDB_SUPPORT_THREAD_LOCAL)
+  endif()
 endif()
 
 option(FAIL_ON_WARNINGS "Treat compile warnings as errors" ON)
@@ -390,8 +393,9 @@ if(NOT WIN32)
 endif()
 
 option(WITH_FALLOCATE "build with fallocate" ON)
-if(WITH_FALLOCATE)
-  CHECK_CXX_SOURCE_COMPILES("
+if(NOT PORTABLE)
+  if(WITH_FALLOCATE)
+    CHECK_CXX_SOURCE_COMPILES("
 #include <fcntl.h>
 #include <linux/falloc.h>
 int main() {
@@ -399,30 +403,31 @@ int main() {
  fallocate(fd, FALLOC_FL_KEEP_SIZE | FALLOC_FL_PUNCH_HOLE, 0, 1024);
 }
 " HAVE_FALLOCATE)
-  if(HAVE_FALLOCATE)
-    add_definitions(-DROCKSDB_FALLOCATE_PRESENT)
+    if(HAVE_FALLOCATE)
+      add_definitions(-DROCKSDB_FALLOCATE_PRESENT)
+    endif()
   endif()
-endif()
 
-CHECK_CXX_SOURCE_COMPILES("
+  CHECK_CXX_SOURCE_COMPILES("
 #include <fcntl.h>
 int main() {
   int fd = open(\"/dev/null\", 0);
   sync_file_range(fd, 0, 1024, SYNC_FILE_RANGE_WRITE);
 }
 " HAVE_SYNC_FILE_RANGE_WRITE)
-if(HAVE_SYNC_FILE_RANGE_WRITE)
-  add_definitions(-DROCKSDB_RANGESYNC_PRESENT)
-endif()
+  if(HAVE_SYNC_FILE_RANGE_WRITE)
+    add_definitions(-DROCKSDB_RANGESYNC_PRESENT)
+  endif()
 
-CHECK_CXX_SOURCE_COMPILES("
+  CHECK_CXX_SOURCE_COMPILES("
 #include <pthread.h>
 int main() {
   (void) PTHREAD_MUTEX_ADAPTIVE_NP;
 }
 " HAVE_PTHREAD_MUTEX_ADAPTIVE_NP)
-if(HAVE_PTHREAD_MUTEX_ADAPTIVE_NP)
-  add_definitions(-DROCKSDB_PTHREAD_ADAPTIVE_MUTEX)
+  if(HAVE_PTHREAD_MUTEX_ADAPTIVE_NP)
+    add_definitions(-DROCKSDB_PTHREAD_ADAPTIVE_MUTEX)
+  endif()
 endif()
 
 include(CheckCXXSymbolExists)

--- a/rocksdb-sys/rocksdb/env/env_posix.cc
+++ b/rocksdb-sys/rocksdb/env/env_posix.cc
@@ -20,7 +20,7 @@
 #include <sys/ioctl.h>
 #include <sys/mman.h>
 #include <sys/stat.h>
-#ifdef OS_LINUX
+#if defined(OS_LINUX) || defined(OS_SOLARIS) || defined(OS_ANDROID)
 #include <sys/statfs.h>
 #include <sys/syscall.h>
 #include <sys/sysmacros.h>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-extern crate rocksdb_sys;
+extern crate parity_rocksdb_sys as rocksdb_sys;
 extern crate local_encoding;
 
 pub use rocksdb_sys::rocksdb_ffi as rocksdb_ffi;

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-extern crate rocksdb;
+extern crate parity_rocksdb as rocksdb;
 use rocksdb::{DB, MergeOperands, Options, Writable};
 
 // fn snapshot_test() {

--- a/test/test.rs
+++ b/test/test.rs
@@ -2,4 +2,4 @@ extern crate parity_rocksdb;
 
 mod test_iterator;
 mod test_multithreaded;
-//mod test_column_family;
+mod test_column_family;

--- a/test/test.rs
+++ b/test/test.rs
@@ -1,4 +1,4 @@
-extern crate rocksdb;
+extern crate parity_rocksdb;
 
 mod test_iterator;
 mod test_multithreaded;

--- a/test/test_column_family.rs
+++ b/test/test_column_family.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-use rocksdb::{DB, MergeOperands, Options, Writable};
+use parity_rocksdb::{DB, MergeOperands, Options, Writable};
 
 #[test]
 pub fn test_column_family() {

--- a/test/test_column_family.rs
+++ b/test/test_column_family.rs
@@ -17,15 +17,19 @@ use parity_rocksdb::{DB, MergeOperands, Options, Writable};
 #[test]
 pub fn test_column_family() {
     let path = "_rust_rocksdb_cftest";
+    let merge_opts = || {
+        let mut opts = Options::new();
+        opts.add_merge_operator("test operator", test_provided_merge);
+        opts
+    };
 
     // should be able to create column families
     {
-        let mut opts = Options::new();
+        let mut opts = merge_opts();
         opts.create_if_missing(true);
-        opts.add_merge_operator("test operator", test_provided_merge);
+
         let mut db = DB::open(&opts, path).unwrap();
-        let opts = Options::new();
-        match db.create_cf("cf1", &opts) {
+        match db.create_cf("cf1", &Options::new()) {
             Ok(_) => println!("cf1 created successfully"),
             Err(e) => {
                 panic!("could not create column family: {}", e);
@@ -35,9 +39,7 @@ pub fn test_column_family() {
 
     // should fail to open db without specifying same column families
     {
-        let mut opts = Options::new();
-        opts.add_merge_operator("test operator", test_provided_merge);
-        match DB::open(&opts, path) {
+        match DB::open(&merge_opts(), path) {
             Ok(_) => {
                 panic!("should not have opened DB successfully without \
                         specifying column
@@ -52,25 +54,22 @@ pub fn test_column_family() {
 
     // should properly open db when specyfing all column families
     {
-        let mut opts = Options::new();
-        opts.add_merge_operator("test operator", test_provided_merge);
-        match DB::open_cf(&opts, path, &["cf1"]) {
+        match DB::open_cf(&merge_opts(), path, &["cf1"], &[merge_opts()]) {
             Ok(_) => println!("successfully opened db with column family"),
             Err(e) => panic!("failed to open db with column family: {}", e),
         }
     }
+
     // TODO should be able to write, read, merge, batch, and iterate over a cf
     {
-        let mut opts = Options::new();
-        opts.add_merge_operator("test operator", test_provided_merge);
-        let db = match DB::open_cf(&opts, path, &["cf1"]) {
+        let db = match DB::open_cf(&merge_opts(), path, &["cf1"], &[merge_opts()]) {
             Ok(db) => {
                 println!("successfully opened db with column family");
                 db
             }
             Err(e) => panic!("failed to open db with column family: {}", e),
         };
-        let cf1 = *db.cf_handle("cf1").unwrap();
+        let cf1 = db.cf_handle("cf1").unwrap();
         assert!(db.put_cf(cf1, b"k1", b"v1").is_ok());
         assert!(db.get_cf(cf1, b"k1").unwrap().unwrap().to_utf8().unwrap() ==
                 "v1");
@@ -81,21 +80,10 @@ pub fn test_column_family() {
         db.merge_cf(cf1, b"k1", b"d").unwrap();
         db.merge_cf(cf1, b"k1", b"efg").unwrap();
         let m = db.merge_cf(cf1, b"k1", b"h");
-        println!("m is {:?}", m);
-        // TODO assert!(m.is_ok());
-        match db.get(b"k1") {
-            Ok(Some(value)) => {
-                match value.to_utf8() {
-                    Some(v) => println!("retrieved utf8 value: {}", v),
-                    None => println!("did not read valid utf-8 out of the db"),
-                }
-            }
-            Err(_) => println!("error reading value"),
-            _ => panic!("value not present!"),
-        }
+        assert!(m.is_ok());
 
-        let _ = db.get_cf(cf1, b"k1");
-        // TODO assert!(r.unwrap().to_utf8().unwrap() == "abcdefgh");
+        let r = db.get_cf(cf1, b"k1");
+        assert!(r.unwrap().unwrap().to_utf8().unwrap() == "abcdefgh");
         assert!(db.delete(b"k1").is_ok());
         assert!(db.get(b"k1").unwrap().is_none());
     }
@@ -107,7 +95,7 @@ pub fn test_column_family() {
     }
     // should b able to drop a cf
     {
-        let mut db = DB::open_cf(&Options::new(), path, &["cf1"]).unwrap();
+        let mut db = DB::open_cf(&merge_opts(), path, &["cf1"], &[merge_opts()]).unwrap();
         match db.drop_cf("cf1") {
             Ok(_) => println!("cf1 successfully dropped."),
             Err(e) => panic!("failed to drop column family: {}", e),

--- a/test/test_iterator.rs
+++ b/test/test_iterator.rs
@@ -1,4 +1,4 @@
-use rocksdb::{DB, Direction, IteratorMode, Options, Writable};
+use parity_rocksdb::{DB, Direction, IteratorMode, Options, Writable};
 
 fn cba(input: &Box<[u8]>) -> Box<[u8]> {
     input.iter().cloned().collect::<Vec<_>>().into_boxed_slice()

--- a/test/test_multithreaded.rs
+++ b/test/test_multithreaded.rs
@@ -1,4 +1,4 @@
-use rocksdb::{DB, Options, Writable};
+use parity_rocksdb::{DB, Options, Writable};
 use std::thread;
 use std::sync::Arc;
 


### PR DESCRIPTION
This is necessary to allow publishing to crates.io. Merge only after https://github.com/paritytech/rust-snappy/pull/6 since we'll want to change our snappy dependency to the one we'll publish to crates.io.