### PR TITLE
Fix build issues on Windows and ARM

### DIFF
--- a/rocksdb-sys/build.rs
+++ b/rocksdb-sys/build.rs
@@ -19,13 +19,19 @@ fn main() {
         println!("cargo:rustc-link-lib=dylib={}", "rpcrt4");
         println!("cargo:rustc-link-lib=dylib={}", "shlwapi");
 
-        let features = env::var("CARGO_CFG_TARGET_FEATURE").unwrap_or(String::new());
+        let features = env::var("CARGO_CFG_TARGET_FEATURE").unwrap_or_default();
         if features.contains("crt-static") {
             cfg.define("WITH_MD_LIBRARY", "OFF");
         }
     } else {
         cfg.define("SNAPPY_INCLUDE_DIR", snappy)
             .define("SNAPPY_LIBRARIES", "/dev/null");
+    }
+
+    // NOTE: the cfg! macro doesn't work when cross-compiling, it would return values for the host
+    let target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap_or_default();
+    if target_arch == "arm" || target_arch == "aarch64" {
+        cfg.define("PORTABLE", "ON");
     }
 
     let out = cfg.build();

--- a/rocksdb-sys/build.rs
+++ b/rocksdb-sys/build.rs
@@ -18,6 +18,11 @@ fn main() {
 
         println!("cargo:rustc-link-lib=dylib={}", "rpcrt4");
         println!("cargo:rustc-link-lib=dylib={}", "shlwapi");
+
+        let features = env::var("CARGO_CFG_TARGET_FEATURE").unwrap_or(String::new());
+        if features.contains("crt-static") {
+            cfg.define("WITH_MD_LIBRARY", "OFF");
+        }
     } else {
         cfg.define("SNAPPY_INCLUDE_DIR", snappy)
             .define("SNAPPY_LIBRARIES", "/dev/null");


### PR DESCRIPTION
This PR fixes some build issues introduced with the migration to CMake.

- Windows - The CMake build defaults to dynamically linking the Windows CRT, although in parity we set it to link statically. The `build.rs` now check the `crt-static` feature to configure CMake accordingly.
- ARM - The CMake build defaults to setting `-march=native` which doesn't work when cross-compiling. Defining `PORTABLE=ON` makes sure the RocksDB build doesn't set `-march=native`.