### PR TITLE
Support old CPUs

### DIFF
--- a/rocksdb-sys/Cargo.toml
+++ b/rocksdb-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parity-rocksdb-sys"
-version = "0.5.2"
+version = "0.5.3"
 authors = ["Tyler Neely <t@jujit.su>", "David Greenberg <dsg123456789@gmail.com>", "Parity Technologies <admin@parity.io>"]
 license = "MIT/Apache-2.0/BSD-3-Clause"
 description = "Native bindings to librocksdb"

--- a/rocksdb-sys/build.rs
+++ b/rocksdb-sys/build.rs
@@ -43,9 +43,9 @@ fn main() {
     let target_arch = env::var("CARGO_CFG_TARGET_ARCH")
         .expect("CARGO_CFG_TARGET_ARCH is set by cargo.");
 
-    if target_arch == "arm" || target_arch == "aarch64" {
-        cfg.define("PORTABLE", "ON");
-    }
+    // Added to support old CPUs
+    // see https://github.com/paritytech/parity-ethereum/issues/9684
+    cfg.define("PORTABLE", "ON");
 
     let out = cfg.build();
 

--- a/rocksdb-sys/build.rs
+++ b/rocksdb-sys/build.rs
@@ -45,7 +45,13 @@ fn main() {
 
     // Added to support old CPUs
     // see https://github.com/paritytech/parity-ethereum/issues/9684
-    cfg.define("PORTABLE", "ON");
+    let portable = match &*env::var("PORTABLE").unwrap_or("ON".to_owned()) {
+        "OFF" => false,
+        _ => true,
+    };
+    if portable {
+        cfg.define("PORTABLE", "ON");
+    }
 
     let out = cfg.build();
 


### PR DESCRIPTION
I could modify `CMakeLists.txt` to something like `-march=core2` and `/arch:AVX` on Windows, but not sure it is the best way, since it would probably create conflicts when updating RocksDB and there are some checks like [this one](https://github.com/paritytech/rust-rocksdb/blob/f1252c84f739ca972be715aed58406f5feb418a3/rocksdb-sys/rocksdb/CMakeLists.txt#L229) that needs to be removed as well. Also I haven't tested this (don't have a new CPU atm) and don't know what the performance impact is. 

Alternatively, we can say that the binaries support only new CPUs and one needs to build from source on an old CPU if needed, but that doesn't seem like a good approach to me, especially in case of Windows.

related to https://github.com/paritytech/parity-ethereum/issues/9684.