### PR TITLE
Remove setting CMAKE_BUILD_SYSTEM manually

### DIFF
--- a/rocksdb-sys/build.rs
+++ b/rocksdb-sys/build.rs
@@ -18,11 +18,6 @@ fn main() {
     let target_os = env::var("CARGO_CFG_TARGET_OS").expect("CARGO_CFG_TARGET_OS is set by cargo.");
     let target_env = env::var("CARGO_CFG_TARGET_ENV").expect("CARGO_CFG_TARGET_ENV is set by cargo.");
 
-    if target_os.contains("android") {
-        // when cross-compiling CMAKE_SYSTEM_NAME is set to the host OS
-        cfg.define("CMAKE_SYSTEM_NAME", "Android");
-    }
-
     if target_env.contains("msvc") {
         cfg.env("SNAPPY_INCLUDE", snappy);
 


### PR DESCRIPTION
(*preamble: it took me around three hours to find out this issue.*)

Right now our Parity Android build works because CI uses CMake 3.5.
CMake 3.5 knows that the `CMAKE_BUILD_SYSTEM` is `Android` but doesn't do anything more about this information.

CMake 3.7, however, did this: (https://cmake.org/cmake/help/v3.7/release/3.7.html#id3)

> CMake now supports Cross Compiling for Android with simple toolchain files.

Now, apparently, when you set `CMAKE_BUILD_SYSTEM` to `Android`, it will automatically try to detect the Android NDK using environment variables and pick the compiler, thereby overriding the compiler that the `cmake-rs` crate sets by passing `CMAKE_C_COMPILER`.
A regular user of CMake is supposed to pass a bunch of `CMAKE_*` variables to properly configure the Android NDK detection, but we can't do that. Instead what I propose here is to simply ignore this whole system.

cc @andresilva
