### PR TITLE
Fix iOS compilation error

### DIFF
--- a/rocksdb-sys/build.rs
+++ b/rocksdb-sys/build.rs
@@ -18,7 +18,14 @@ fn main() {
     let target_os = env::var("CARGO_CFG_TARGET_OS").expect("CARGO_CFG_TARGET_OS is set by cargo.");
     let target_env = env::var("CARGO_CFG_TARGET_ENV").expect("CARGO_CFG_TARGET_ENV is set by cargo.");
 
+    if target_os.contains("ios") {
+        cfg.define("CMAKE_OSX_SYSROOT", "");
+        cfg.define("IOS_CROSS_COMPILE", "");
+    }
+
     if target_os.contains("windows") {
+        cfg.env("SNAPPY_INCLUDE", snappy);
+
         println!("cargo:rustc-link-lib=dylib={}", "rpcrt4");
         println!("cargo:rustc-link-lib=dylib={}", "shlwapi");
     }
@@ -64,7 +71,7 @@ fn main() {
     println!("cargo:rustc-link-lib=static=snappy");
 
     // https://github.com/alexcrichton/cc-rs/blob/ca70fd32c10f8cea805700e944f3a8d1f97d96d4/src/lib.rs#L891
-    if target_os.contains("macos") || target_os.contains("freebsd") || target_os.contains("openbsd") {
+    if target_os.contains("macos") || target_os.contains("ios") || target_os.contains("freebsd") || target_os.contains("openbsd") {
         println!("cargo:rustc-link-lib=c++");
     } else if !target_env.contains("msvc") && !target_os.contains("android") {
         println!("cargo:rustc-link-lib=stdc++");

--- a/rocksdb-sys/build.rs
+++ b/rocksdb-sys/build.rs
@@ -24,8 +24,6 @@ fn main() {
     }
 
     if target_os.contains("windows") {
-        cfg.env("SNAPPY_INCLUDE", snappy);
-
         println!("cargo:rustc-link-lib=dylib={}", "rpcrt4");
         println!("cargo:rustc-link-lib=dylib={}", "shlwapi");
     }

--- a/rocksdb-sys/rocksdb/db/db_impl.cc
+++ b/rocksdb-sys/rocksdb/db/db_impl.cc
@@ -2706,14 +2706,16 @@ void DBImpl::EraseThreadStatusDbInfo() const {}
 
 //
 // A global method that can dump out the build version
-void DumpRocksDBBuildVersion(Logger* log) {
 #if !defined(IOS_CROSS_COMPILE)
+void DumpRocksDBBuildVersion(Logger* log) {
   // if we compile with Xcode, we don't run build_detect_version, so we don't
   // generate util/build_version.cc
   ROCKS_LOG_HEADER(log, "RocksDB version: %d.%d.%d\n", ROCKSDB_MAJOR,
                    ROCKSDB_MINOR, ROCKSDB_PATCH);
   ROCKS_LOG_HEADER(log, "Git sha %s", rocksdb_build_git_sha);
   ROCKS_LOG_HEADER(log, "Compile date %s", rocksdb_build_compile_date);
+#else
+void DumpRocksDBBuildVersion(Logger* log __attribute__((__unused__))) {
 #endif
 }
 

--- a/rocksdb-sys/rocksdb/db/db_impl.cc
+++ b/rocksdb-sys/rocksdb/db/db_impl.cc
@@ -2706,8 +2706,8 @@ void DBImpl::EraseThreadStatusDbInfo() const {}
 
 //
 // A global method that can dump out the build version
-#if !defined(IOS_CROSS_COMPILE)
 void DumpRocksDBBuildVersion(Logger* log) {
+#if !defined(IOS_CROSS_COMPILE)
   // if we compile with Xcode, we don't run build_detect_version, so we don't
   // generate util/build_version.cc
   ROCKS_LOG_HEADER(log, "RocksDB version: %d.%d.%d\n", ROCKSDB_MAJOR,
@@ -2715,7 +2715,7 @@ void DumpRocksDBBuildVersion(Logger* log) {
   ROCKS_LOG_HEADER(log, "Git sha %s", rocksdb_build_git_sha);
   ROCKS_LOG_HEADER(log, "Compile date %s", rocksdb_build_compile_date);
 #else
-void DumpRocksDBBuildVersion(Logger* log __attribute__((__unused__))) {
+  (void)log;  // ignore "-Wunused-parameter"
 #endif
 }
 


### PR DESCRIPTION
Without this fix CMake failed with:

```
clang: warning: using sysroot for 'MacOSX' but targeting 'iPhone' [-Wincompatible-sysroot]
```

Can be reproduced by running:

```
cargo build --target=aarch64-apple-ios
```