### PR TITLE
Set new_value_length to result.len instead of always to 1

### DIFF
--- a/src/merge_operator.rs
+++ b/src/merge_operator.rs
@@ -94,7 +94,7 @@ pub extern "C" fn partial_merge_callback(raw_cb: *mut c_void,
         // TODO(tan) investigate zero-copy techniques to improve performance
         let buf = libc::malloc(result.len() as size_t);
         assert!(!buf.is_null());
-        *new_value_length = 1 as size_t;
+        *new_value_length = result.len() as size_t;
         *success = 1 as u8;
         ptr::copy(result.as_ptr() as *mut c_void, &mut *buf, result.len());
         buf as *const c_char


### PR DESCRIPTION
Was having problems with a 1 sized slice being sent back in after restarting db.